### PR TITLE
Remove visible_light property

### DIFF
--- a/adafruit_ltr329_ltr303.py
+++ b/adafruit_ltr329_ltr303.py
@@ -175,16 +175,6 @@ class LTR329:
             raise ValueError("Data invalid / over-run!")
         return self._light_data & 0xFFFF
 
-    @property
-    def visible_light(self) -> int:
-        """The visible light data"""
-        temp = self._light_data
-        if self.als_data_invalid:
-            raise ValueError("Data invalid / over-run!")
-        infra = temp & 0xFFFF
-        vis_infra = temp >> 16
-        return vis_infra - infra
-
 
 class LTR303(LTR329):
     """Base driver for the LTR-303 light sensor, basically an LTR-329 with INT out

--- a/examples/ltr303_advancedtest.py
+++ b/examples/ltr303_advancedtest.py
@@ -70,7 +70,6 @@ while True:
             # Now we can do various math...
             print("Visible + IR:", visible_plus_ir)
             print("Infrared    :", ir)
-            print("Visible     :", visible_plus_ir - ir)
             print("ALS gain:   :", ltr303.als_data_gain)
             print()
         except ValueError:

--- a/examples/ltr303_simpletest.py
+++ b/examples/ltr303_simpletest.py
@@ -14,6 +14,5 @@ ltr303 = LTR303(i2c)
 while True:
     print("Visible + IR:", ltr303.visible_plus_ir_light)
     print("Infrared    :", ltr303.ir_light)
-    print("Visible     :", ltr303.visible_light)
     print()
     time.sleep(0.5)  # sleep for half a second

--- a/examples/ltr329_advancedtest.py
+++ b/examples/ltr329_advancedtest.py
@@ -4,15 +4,12 @@
 
 import time
 import board
-from adafruit_debug_i2c import DebugI2C
 import adafruit_ltr329_ltr303 as adafruit_ltr329
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 
-debug_i2c = DebugI2C(i2c)
-
 time.sleep(0.1)  # sensor takes 100ms to 'boot' on power up
-ltr329 = adafruit_ltr329.LTR329(debug_i2c)
+ltr329 = adafruit_ltr329.LTR329(i2c)
 
 # Can set the ALS light gain, can be: 1, 2, 4, 8, 48 or 96 times
 # to range from 1~64 kLux to 0.01~600 Lux
@@ -56,7 +53,6 @@ while True:
             # Now we can do various math...
             print("Visible + IR:", visible_plus_ir)
             print("Infrared    :", ir)
-            print("Visible     :", visible_plus_ir - ir)
             print("ALS gain:   :", ltr329.als_data_gain)
             print()
         except ValueError:

--- a/examples/ltr329_simpletest.py
+++ b/examples/ltr329_simpletest.py
@@ -14,6 +14,5 @@ ltr329 = LTR329(i2c)
 while True:
     print("Visible + IR:", ltr329.visible_plus_ir_light)
     print("Infrared    :", ltr329.ir_light)
-    print("Visible     :", ltr329.visible_light)
     print()
     time.sleep(0.5)  # sleep for half a second


### PR DESCRIPTION
For #2.

Removes the`visible_light` property which was reporting negative values. Examples also updated (and tested).

Related issue with more discussion here:
https://github.com/adafruit/Adafruit_LTR329_LTR303/issues/1