### PR TITLE
BREAKING CHANGE - cleans up spelling.

### DIFF
--- a/adafruit_ltr329_ltr303.py
+++ b/adafruit_ltr329_ltr303.py
@@ -121,7 +121,7 @@ class LTR329:
     @property
     def integration_time(self) -> int:
         """ALS integration times, can be: 50, 100, 150, 200, 250,
-        300, 350, or 400 millisec"""
+        300, 350, or 400 milliseconds"""
         return _integration_times[self._integration_time]
 
     @integration_time.setter
@@ -129,21 +129,21 @@ class LTR329:
         if not int_time in _integration_times:
             raise RuntimeError(
                 "Invalid integration time: must be 50, 100, 150, "
-                "200, 250, 300, 350, or 400 millisec"
+                "200, 250, 300, 350, or 400 milliseconds"
             )
         self._integration_time = _integration_times.index(int_time)
 
     @property
     def measurement_rate(self) -> int:
         """ALS measurement rate, must be = or > than ALS integration rate!
-        Can be: 50, 100, 200, 500, 1000, or 2000 millisec"""
+        Can be: 50, 100, 200, 500, 1000, or 2000 milliseconds"""
         return _measurement_rates[self._measurement_rate]
 
     @measurement_rate.setter
     def measurement_rate(self, rate: int) -> None:
         if not rate in _measurement_rates:
             raise RuntimeError(
-                "Invalid measurement rate: must be 50, 100, 200, 500, 1000, or 2000 millisec"
+                "Invalid measurement rate: must be 50, 100, 200, 500, 1000, or 2000 milliseconds"
             )
         self._measurement_rate = _measurement_rates.index(rate)
 
@@ -189,25 +189,25 @@ class LTR303(LTR329):
     threshold_high = UnaryStruct(_LTR303_REG_THRESHHIGH_LSB, "<H")
     threshold_low = UnaryStruct(_LTR303_REG_THRESHLOW_LSB, "<H")
 
-    _int_persistance = RWBits(4, _LTR303_REG_INTPERSIST, 0)
+    _int_persistence = RWBits(4, _LTR303_REG_INTPERSIST, 0)
 
     @property
-    def int_persistance(self) -> int:
+    def int_persistence(self) -> int:
         """How long the data needs to be high/low to generate an interrupt.
         Setting of 1 means 'every measurement', 2 means "two in a row", etc
         up to 16
         """
-        return self._int_persistance + 1
+        return self._int_persistence + 1
 
-    @int_persistance.setter
-    def int_persistance(self, counts: int) -> None:
+    @int_persistence.setter
+    def int_persistence(self, counts: int) -> None:
         if not 1 <= counts <= 16:
-            raise ValueError("Persistance counts must be 1-16")
-        self._int_persistance = counts - 1
+            raise ValueError("Persistence counts must be 1-16")
+        self._int_persistence = counts - 1
 
     @property
     def enable_int(self) -> bool:
-        """Whether the interupt is enabled"""
+        """Enable the interrupt functionality."""
         return self._enable_int
 
     @enable_int.setter
@@ -222,7 +222,7 @@ class LTR303(LTR329):
 
     @property
     def int_polarity(self) -> bool:
-        """The polarity of the interupt (whether high or low is "active")"""
+        """The polarity of the interrupt (whether high or low is "active")"""
         return self._int_polarity
 
     @int_polarity.setter

--- a/examples/ltr303_advancedtest.py
+++ b/examples/ltr303_advancedtest.py
@@ -35,7 +35,7 @@ print("LTR-303 measurement rate (ms):", ltr303.measurement_rate)
 # The interrupt output can be enabled
 ltr303.enable_int = True
 # We can also change whether the polarity is active LOW (False) or HIGH (True)
-ltr303.int_polarity = False
+ltr303.int_polarity = True
 
 # Then set the low and high thresholds that would trigger an IRQ!
 ltr303.threshold_low = 2000  # interrupt goes off if BELOW this number

--- a/examples/ltr303_advancedtest.py
+++ b/examples/ltr303_advancedtest.py
@@ -43,10 +43,10 @@ ltr303.threshold_high = 40000  # or ABOVE this number!
 print("Interrupt thresholds:", ltr303.threshold_low, ltr303.threshold_high)
 
 # Finally, we can set how many measurements must be above/below before
-# we trigger an IRQ - basically avoid spurious readings. A seting of 1
+# we trigger an IRQ - basically avoid spurious readings. A setting of 1
 # means every value triggers an int, 2 means two consecutive readings to
 # trigger... up to 16!
-ltr303.int_persistance = 4
+ltr303.int_persistence = 4
 
 while True:
     # The sensor will let us know when the measurement time has

--- a/examples/ltr329_advancedtest.py
+++ b/examples/ltr329_advancedtest.py
@@ -18,13 +18,13 @@ print("LTR-329 ALS gain:", ltr329.als_gain)
 
 # Can set the ALS measurement integration time, how long the sensor
 # 'looks' for light data. Default is 100ms.
-# Set to: 50, 100, 150, 200, 250, 300, 350, or 400 millisec
+# Set to: 50, 100, 150, 200, 250, 300, 350, or 400 milliseconds
 # ltr329.integration_time = 50
 print("LTR-329 integration time (ms):", ltr329.integration_time)
 
 # Can set the ALS measurement rate, how often the data register updates
 # Default is 500ms. Must be equal or greater than the integration time
-# Set to: 50, 100, 200, 500, 1000, 2000 millisec
+# Set to: 50, 100, 200, 500, 1000, 2000 milliseconds
 # ltr329.measurement_rate = 500
 print("LTR-329 measurement rate (ms):", ltr329.measurement_rate)
 


### PR DESCRIPTION
This PR cleans up some spelling issues, which includes one of the property names. Consider this a breaking change.

Also flips polarity in the `ltr303_advanced_test` to `True` to work with attaching an LED to the int pin to see when it is triggered.