### PR TITLE
Return polarity to False.

### DIFF
--- a/examples/ltr303_advancedtest.py
+++ b/examples/ltr303_advancedtest.py
@@ -35,7 +35,8 @@ print("LTR-303 measurement rate (ms):", ltr303.measurement_rate)
 # The interrupt output can be enabled
 ltr303.enable_int = True
 # We can also change whether the polarity is active LOW (False) or HIGH (True)
-ltr303.int_polarity = True
+# Default is LOW (False)
+ltr303.int_polarity = False
 
 # Then set the low and high thresholds that would trigger an IRQ!
 ltr303.threshold_low = 2000  # interrupt goes off if BELOW this number


### PR DESCRIPTION
Interrupt pins are meant to pull low when active. Turns out the solution is to wire the LED to 3.3V instead of ground, not to alter the polarity. 